### PR TITLE
新版运动路径插件修复无法ctrl Z bug

### DIFF
--- a/_BsKeyTools/Scripts/BulletScripts/Quote/DTrajEdit_New.ms
+++ b/_BsKeyTools/Scripts/BulletScripts/Quote/DTrajEdit_New.ms
@@ -390,6 +390,10 @@ struct yunTrajEdit_Globals_Struct
 ------生成轨迹函数  物体 显示 开点 开始色 结束色 开始帧数 结束帧数 点形状 播放是否显示 关键帧开关 是否颜色渐变
 fn yunMotionPathCallBackFn  obj vis isdot col_Start  col_End tStart tEnd dotShape isPlay keyVis isGradual =
 (
+	-- Wrap entire function in undo off to prevent at time evaluations from corrupting undo stack
+	-- This fixes the bug where Ctrl+Z doesn't work when trajectory plugin is active
+	undo off
+	(
 	-- Save all selected Biped poses before at time access (to restore later and prevent pose reset)
 	local savedBipeds = #()
 	local savedBipedPoses = #()
@@ -633,6 +637,7 @@ fn yunMotionPathCallBackFn  obj vis isdot col_Start  col_End tStart tEnd dotShap
 		gw.enlargeUpdateRect #whole
 		gw.updateScreen()
 	)
+	) -- end undo off
 )
 function yunMotionPathCallBackFn_exc =
 (


### PR DESCRIPTION
## 改动说明
新版运动路径插件修复无法ctrl Z的bug


## 改动类型

- [ ] 🐛 Bug 修复

## 相关 Issue

Fixes #(issue 编号)
https://github.com/AniBullet/BsKeyTools/issues/16

## 测试环境

- **3ds Max 版本**: 2024
- **操作系统**: window11

## 截图/演示
<!-- 如果有界面改动或新功能，请提供截图或 GIF -->
![undoBugFix](https://github.com/user-attachments/assets/41bf1cb8-6b04-4235-a368-ed65ba71f68b)



## 检查清单

- [ ] 代码已测试
- [ ] 添加了必要注释
- [ ] PR 提交到 `dev` 分支

---

感谢你的贡献！🎉
